### PR TITLE
Add "Open in LaunchDarkly" editor command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,8 @@
 	"search.exclude": {
 		"out": true
 	},
-	"editor.formatOnSave": true,
 	"prettier.singleQuote": true,
 	"prettier.useTabs": true,
 	"prettier.trailingComma": "all",
-	"prettier.printWidth": 80
+	"prettier.printWidth": 120
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the "launchdarkly" extension will be documented in this file.
 
-## [2.0.0] - 2018-08-08
+## [2.0.0] - 2018-08-16
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
+
 All notable changes to the "launchdarkly" extension will be documented in this file.
 
+## [2.0.0] - 2018-08-08
+
+### Added
+
+- The LaunchDarkly base and stream uris are now configurable.
+
+### Changed
+
+- Replace the "Get feature flag" command with an "Open in LaunchDarkly" command to view a feature flag in the LaunchDarkly dashboard.
+
+### Fixed
+
+- Flag keys with non-letter characters are now correctly discovered by the extension
+
 ## [1.0.0] - 2017-08-10
+
 - Initial release

--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
 # LaunchDarkly VSCode Extension
 
-This extension aims to provide an accessibility layer for LaunchDarkly's REST API and streaming platform.
+The LaunchDarkly VSCode extension provides some quality-of-life enhancements for interacting with feature flags within VSCode.
 
 ## Features
-Display a flag configuration
 
-![flag config](https://github.com/launchdarkly/ld-vscode/blob/master/images/get-feature-flag.gif?raw=true "Display a flag Configuration")
-
-LaunchDarkly language support
-  * Flag details tooltip on hover
-  * Flag name completion
+- Flag details tooltip on hover
+- Flag name autocomplete
+- Open feature flags in LaunchDarkly (Default keybind: `ctrl+alt+g`/`⌘+alt+g`)
 
 ## Extension Settings
 
 This extension contributes the following settings:
-* `launchdarkly.sdkKey`: Your LaunchDarkly SDK key.
-* `launchdarkly.accessToken`: Your LaunchDarkly API access token.
-* `launchdarkly.project`: Your LaunchDarkly project key.
-* `launchdarkly.env`: Your LaunchDarkly environment key.
-* `launchdarkly.clearOutputBeforeEveryCommand`: If `true`, the output channel is cleared between commands.
-
+| Setting                      | Description                                                                     | Default value                     |
+| ---------------------------- |:-------------------------------------------------------------------------------:| --------------------------------: |
+| `launchdarkly.sdkKey`        | Your LaunchDarkly SDK key. Required.                                            | undefined                         |
+| `launchdarkly.accessToken`   | Your LaunchDarkly API access token. Required.                                   | undefined                         |
+| `launchdarkly.project`       | Your LaunchDarkly project key, should match the provided SDK key. Required.     | undefined                         |
+| `launchdarkly.env`           | Your LaunchDarkly environment key, should match the provided SDK key. Required. | first environment                 |
+| `launchdarkly.baseUri`       | The LaunchDarkly base uri to be used. Optional.                                 | `https://app.launchdarkly.com`    |
+| `launchdarkly.streamUri`     | The LaunchDarkly stream uri to be used. Optional.                               | `https://stream.launchdarkly.com` |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The LaunchDarkly VSCode extension provides some quality-of-life enhancements for
 ## Extension Settings
 
 This extension contributes the following settings:
+
 | Setting                      | Description                                                                     | Default value                     |
 | ---------------------------- |:-------------------------------------------------------------------------------:| --------------------------------: |
 | `launchdarkly.sdkKey`        | Your LaunchDarkly SDK key. Required.                                            | undefined                         |

--- a/package.json
+++ b/package.json
@@ -2,15 +2,19 @@
 	"name": "launchdarkly",
 	"displayName": "LaunchDarkly",
 	"description": "Retrieve LaunchDarkly feature flags in your editor.",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"publisher": "launchdarkly",
 	"engines": {
 		"vscode": "^1.14.0"
 	},
-	"categories": ["Other"],
+	"categories": [
+		"Other"
+	],
 	"icon": "images/launchdarkly.png",
 	"license": "SEE LICENSE IN LICENSE.txt",
-	"activationEvents": ["*"],
+	"activationEvents": [
+		"*"
+	],
 	"main": "./out/src/extension",
 	"contributes": {
 		"configuration": {
@@ -26,44 +30,55 @@
 					"description": "LaunchDarkly SDK key"
 				},
 				"launchdarkly.project": {
-					"type": ["string", "null"],
+					"type": [
+						"string",
+						"null"
+					],
 					"default": null,
 					"description": "LaunchDarkly project key"
 				},
 				"launchdarkly.env": {
-					"type": ["string", "null"],
+					"type": [
+						"string",
+						"null"
+					],
 					"default": null,
 					"description": "LaunchDarkly environment key"
 				},
-				"launchdarkly.clearOutputBeforeEveryCommand": {
-					"type": "boolean",
-					"default": true,
-					"description": "Clears the output console every time new data is displayed."
+				"launchdarkly.baseUri": {
+					"type": "string",
+					"default": "https://app.launchdarkly.com",
+					"description": "LaunchDarkly base uri"
+				},
+				"launchdarkly.streamUri": {
+					"type": "string",
+					"default": "https://stream.launchdarkly.com",
+					"description": "LaunchDarkly stream uri"
 				}
 			}
 		},
 		"commands": [
 			{
-				"command": "extension.getFlag",
-				"title": "LaunchDarkly: Get Flag Selection",
-				"when": "editorHasSelection"
+				"command": "extension.openInLaunchDarkly",
+				"title": "LaunchDarkly: Open in LaunchDarkly",
+				"when": "editorTextFocus"
 			}
 		],
 		"menus": {
 			"editor/context": [
 				{
-					"command": "extension.getFlag",
-					"when": "editorHasSelection",
+					"command": "extension.openInLaunchDarkly",
+					"when": "editorTextFocus",
 					"group": "LaunchDarkly"
 				}
 			]
 		},
 		"keybindings": [
 			{
-				"command": "extension.getFlag",
+				"command": "extension.openInLaunchDarkly",
 				"key": "ctrl+alt+g",
 				"mac": "cmd+alt+g",
-				"when": "editorHasSelection"
+				"when": "editorTextFocus"
 			}
 		]
 	},
@@ -85,8 +100,10 @@
 		"yarn": "^0.27.5"
 	},
 	"dependencies": {
+		"@types/opn": "5.1.0",
 		"eventsource": "^1.0.5",
 		"ldclient-node": "5.1.1",
+		"opn": "5.3.0",
 		"request": "^2.81.0",
 		"requestify": "^0.2.5",
 		"vscode": "^1.1.8"

--- a/package.json
+++ b/package.json
@@ -101,9 +101,11 @@
 		"yarn": "^0.27.5"
 	},
 	"dependencies": {
+		"@types/lodash": "4.14.116",
 		"@types/opn": "5.1.0",
 		"eventsource": "^1.0.5",
 		"ldclient-node": "5.1.1",
+		"lodash.kebabcase": "4.1.1",
 		"opn": "5.3.0",
 		"request": "2.88.0",
 		"vscode": "^1.1.8"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "launchdarkly",
 	"displayName": "LaunchDarkly",
-	"description": "Retrieve LaunchDarkly feature flags in your editor.",
+	"description": "View LaunchDarkly feature flags in your editor.",
 	"version": "2.0.0",
 	"publisher": "launchdarkly",
 	"engines": {
@@ -20,7 +20,7 @@
 	"contributes": {
 		"configuration": {
 			"type": "object",
-			"title": "LaunchDarkly configuration",
+			"title": "LaunchDarkly",
 			"properties": {
 				"launchdarkly.accessToken": {
 					"type": "string",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"engines": {
 		"vscode": "^1.14.0"
 	},
+	"repository": "https://github.com/launchdarkly/ld-vscode",
 	"categories": [
 		"Other"
 	],
@@ -104,8 +105,7 @@
 		"eventsource": "^1.0.5",
 		"ldclient-node": "5.1.1",
 		"opn": "5.3.0",
-		"request": "^2.81.0",
-		"requestify": "^0.2.5",
+		"request": "2.88.0",
 		"vscode": "^1.1.8"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
 		"lib": ["es6"],
 		"sourceMap": true,
 		"rootDir": ".",
-		"allowJs": true
 	},
 	"exclude": ["node_modules", ".vscode-test", "./out"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
 		"outDir": "./out",
 		"lib": ["es6"],
 		"sourceMap": true,
-		"rootDir": ".",
+		"rootDir": "."
 	},
 	"exclude": ["node_modules", ".vscode-test", "./out"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,6 +6,10 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
 
+"@types/lodash@4.14.116":
+  version "4.14.116"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
+
 "@types/mocha@^2.2.32":
   version "2.2.41"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.41.tgz#e27cf0817153eb9f2713b2d3f6c68f1e1c3ca608"
@@ -1260,6 +1264,10 @@ lodash.clonedeep@^4.0.1:
 lodash.isequal@^4.0.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
+lodash.kebabcase@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
 
 lodash.toarray@^4.4.0:
   version "4.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,12 @@
   version "6.0.85"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.85.tgz#ec02bfe54a61044f2be44f13b389c6a0e8ee05ae"
 
+"@types/opn@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/opn/-/opn-5.1.0.tgz#bff7bc371677f4bdbb37884400e03fd81f743927"
+  dependencies:
+    "@types/node" "*"
+
 "@types/redis@2.8.6":
   version "2.8.6"
   resolved "https://registry.yarnpkg.com/@types/redis/-/redis-2.8.6.tgz#3674d07a13ad76bccda4c37dc3909e4e95757e7e"
@@ -1114,6 +1120,10 @@ is-valid-glob@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-0.3.0.tgz#d4b55c69f51886f9b65c70d6c2622d37e29f48fe"
 
+is-wsl@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
+
 is@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/is/-/is-3.2.1.tgz#d0ac2ad55eb7b0bec926a5266f6c662aaa83dca5"
@@ -1479,6 +1489,12 @@ onetime@^2.0.0:
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
   dependencies:
     mimic-fn "^1.0.0"
+
+opn@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/opn/-/opn-5.3.0.tgz#64871565c863875f052cfdf53d3e3cb5adb53b1c"
+  dependencies:
+    is-wsl "^1.1.0"
 
 ordered-read-streams@^0.3.0:
   version "0.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,7 +38,7 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0:
+ajv@^5.1.0, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -173,6 +173,10 @@ aws-sign2@~0.7.0:
 aws4@^1.2.1, aws4@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
+
+aws4@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
 babel-runtime@^6.0.0:
   version "6.25.0"
@@ -355,7 +359,7 @@ colors@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
-combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
+combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5, combined-stream@~1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
@@ -615,7 +619,7 @@ extend-shallow@^2.0.1:
   dependencies:
     is-extendable "^0.1.0"
 
-extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
+extend@^3.0.0, extend@~3.0.0, extend@~3.0.1, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
@@ -705,7 +709,7 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-form-data@~2.3.1:
+form-data@~2.3.1, form-data@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
   dependencies:
@@ -914,6 +918,13 @@ har-validator@~5.0.3:
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
   dependencies:
     ajv "^5.1.0"
+    har-schema "^2.0.0"
+
+har-validator@~5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.0.tgz#44657f5688a22cfd4b72486e81b3a3fb11742c29"
+  dependencies:
+    ajv "^5.3.0"
     har-schema "^2.0.0"
 
 has-ansi@^2.0.0:
@@ -1153,10 +1164,6 @@ jade@0.26.3:
     commander "0.6.1"
     mkdirp "0.3.0"
 
-jquery@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
-
 js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -1330,7 +1337,7 @@ mime-db@~1.35.0:
   version "1.35.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
 
-mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.7:
   version "2.1.19"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
   dependencies:
@@ -1456,6 +1463,10 @@ nth-check@~1.0.1:
 oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
 
 object-assign@^4.0.0:
   version "4.1.1"
@@ -1599,6 +1610,10 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
+psl@^1.1.24:
+  version "1.1.29"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
+
 pump@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.2.tgz#3b3ee6512f94f0e575538c17995f9f16990a5d51"
@@ -1618,15 +1633,11 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-q@^0.9.7:
-  version "0.9.7"
-  resolved "https://registry.yarnpkg.com/q/-/q-0.9.7.tgz#4de2e6cb3b29088c9e4cbc03bf9d42fb96ce2f75"
-
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
-qs@~6.5.1:
+qs@~6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
@@ -1779,6 +1790,31 @@ request@2.87.0, request@^2.67.0, request@^2.79.0, request@^2.83.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
+request@2.88.0:
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
+
 request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
@@ -1805,14 +1841,6 @@ request@^2.81.0:
     tough-cookie "~2.3.0"
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
-
-requestify@^0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/requestify/-/requestify-0.2.5.tgz#80249f1ca7dfdf79fa2a6048aeac37d43e23c905"
-  dependencies:
-    jquery "^3.1.0"
-    q "^0.9.7"
-    underscore "^1.8.3"
 
 requires-port@1.0.x, requires-port@^1.0.0:
   version "1.0.0"
@@ -1857,7 +1885,7 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
@@ -2104,6 +2132,13 @@ tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   dependencies:
     punycode "^1.4.1"
 
+tough-cookie@~2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  dependencies:
+    psl "^1.1.24"
+    punycode "^1.4.1"
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -2121,10 +2156,6 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
 typescript@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
-
-underscore@^1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
 unique-stream@^2.0.2:
   version "2.2.1"
@@ -2159,7 +2190,7 @@ utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
 
-uuid@^3.0.0, uuid@^3.1.0:
+uuid@^3.0.0, uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 


### PR DESCRIPTION
This PR replaces the existing "get flag" command (opens a new output channel with flag json) with an "open in ld" command, which opens the flag's dashboard link in a new browser tab.

Since we're removing an existing command, this change will require a major version release.