### PR TITLE
upgrade node.extend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "launchdarkly" extension will be documented in this file.
 
+## [2.0.4] - 2019-02-07
+
+### Changed
+
+- Locked indirect dependency `node.extend` to versions ^1.1.7.
+
 ## [2.0.3] - 2018-11-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ This extension contributes the following settings:
 
 | Setting                           | Description                                                                     | Default value                     |
 | --------------------------------- |:-------------------------------------------------------------------------------:| --------------------------------: |
-| `launchdarkly.sdkKey`             | Your LaunchDarkly SDK key. Required.                                            | undefined                         |
-| `launchdarkly.accessToken`        | Your LaunchDarkly API access token. Required.                                   | undefined                         |
-| `launchdarkly.project`            | Your LaunchDarkly project key, should match the provided SDK key. Required.     | undefined                         |
+| `launchdarkly.sdkKey`             | Your LaunchDarkly SDK key. Required.                                            | `undefined`                         |
+| `launchdarkly.accessToken`        | Your LaunchDarkly API access token. Required.                                   | `undefined`                         |
+| `launchdarkly.project`            | Your LaunchDarkly project key, should match the provided SDK key. Required.     | `undefined`                         |
 | `launchdarkly.env`                | Your LaunchDarkly environment key, should match the provided SDK key.           | first environment                 |
 | `launchdarkly.baseUri`            | The LaunchDarkly base uri to be used. Optional.                                 | `https://app.launchdarkly.com`    |
 | `launchdarkly.streamUri`          | The LaunchDarkly stream uri to be used. Optional.                               | `https://stream.launchdarkly.com` |
-| `launchdarkly.enableHover`        | Enables flag info to be displayed on hover of a valid flag key.                 | true                              |
-| `launchdarkly.enableAutocomplete` | Enable flag key autocompletion.                                                 | true                              |
+| `launchdarkly.enableHover`        | Enables flag info to be displayed on hover of a valid flag key.                 | `true`                              |
+| `launchdarkly.enableAutocomplete` | Enable flag key autocompletion.                                                 | `true`                              |
 
 **Note:** If you use quick suggestions to autocomplete words, LaunchDarkly autocomplete functionality requires the `editor.quickSuggestions.strings` setting to be enabled. Otherwise, you'll need to press `Ctrl+Space` (default binding) to see your flag key suggestions.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -888,6 +888,11 @@
 				"rimraf": "2"
 			}
 		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -1262,6 +1267,14 @@
 				"har-schema": "^2.0.0"
 			}
 		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
 		"has-ansi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -1451,9 +1464,9 @@
 			}
 		},
 		"is": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
-			"integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU="
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+			"integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
 		},
 		"is-buffer": {
 			"version": "1.1.6",
@@ -1969,11 +1982,12 @@
 			"integrity": "sha1-VmL8eZ8cPJXZPjAV3QSAZVFJhdM="
 		},
 		"node.extend": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
-			"integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.8.tgz",
+			"integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
 			"requires": {
-				"is": "^3.1.0"
+				"has": "^1.0.3",
+				"is": "^3.2.1"
 			}
 		},
 		"normalize-path": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "launchdarkly",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "launchdarkly",
 	"displayName": "LaunchDarkly",
 	"description": "View LaunchDarkly feature flags in your editor.",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"publisher": "launchdarkly",
 	"engines": {
 		"vscode": "^1.18.0"

--- a/package.json
+++ b/package.json
@@ -115,5 +115,8 @@
 		"opn": "5.3.0",
 		"request": "2.88.0",
 		"vscode": "^1.1.8"
+	},
+	"resolutions": {
+		"node.extend": "^1.1.7"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
 		"prettier": "^1.5.3",
 		"pretty-error": "^2.1.1",
 		"typescript": "^2.4.2",
-		"yarn": "^0.27.5"
+		"yarn": "^0.27.5",
+		"vscode": "^1.1.8"
 	},
 	"dependencies": {
 		"@types/lodash": "4.14.116",
@@ -113,8 +114,7 @@
 		"ldclient-node": "5.4.2",
 		"lodash.kebabcase": "4.1.1",
 		"opn": "5.3.0",
-		"request": "2.88.0",
-		"vscode": "^1.1.8"
+		"request": "2.88.0"
 	},
 	"resolutions": {
 		"node.extend": "^1.1.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -872,6 +872,11 @@ fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
@@ -1098,6 +1103,13 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
 
 hawk@~3.1.3:
   version "3.1.3"
@@ -1334,10 +1346,10 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-is@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/is/-/is-3.2.1.tgz#d0ac2ad55eb7b0bec926a5266f6c662aaa83dca5"
-  integrity sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=
+is@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/is/-/is-3.3.0.tgz#61cff6dd3c4193db94a3d62582072b44e5645d79"
+  integrity sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==
 
 isarray@0.0.1:
   version "0.0.1"
@@ -1685,12 +1697,13 @@ node-sha1@0.0.1:
   resolved "https://registry.yarnpkg.com/node-sha1/-/node-sha1-0.0.1.tgz#5662fc799f1c3c95d93e3015dd048065514985d3"
   integrity sha1-VmL8eZ8cPJXZPjAV3QSAZVFJhdM=
 
-node.extend@^1.1.2:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/node.extend/-/node.extend-1.1.6.tgz#a7b882c82d6c93a4863a5504bd5de8ec86258b96"
-  integrity sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=
+node.extend@^1.1.2, node.extend@^1.1.7:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/node.extend/-/node.extend-1.1.8.tgz#0aab3e63789f4e6d68b42bc00073ad1881243cf0"
+  integrity sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==
   dependencies:
-    is "^3.1.0"
+    has "^1.0.3"
+    is "^3.2.1"
 
 normalize-path@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
low severity vulnerability found in the existing version of `node.extend`, which is an indirect dependency of `ld-vscode`: https://snyk.io/vuln/SNYK-JS-NODEEXTEND-73641