### PR TITLE
(1/x) Break out models and api, refactor classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
 		"launchdarkly-node-server-sdk": "5.10.0",
 		"lodash.kebabcase": "4.1.1",
 		"opn": "5.3.0",
-		"request": "2.88.0"
+		"request-promise-native": "1.0.8"
 	},
 	"resolutions": {
 		"node.extend": "^1.1.7",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,26 @@
+import * as rp from 'request-promise-native';
+import * as url from 'url';
+
+import { configuration } from './configuration';
+import { Flag } from './models';
+
+// LaunchDarklyAPI is a wrapper around request-promise-native for requesting data from LaunchDarkly's REST API. The caller is expected to catch all exceptions.
+class LaunchDarklyAPI {
+	async getFeatureFlag(projectKey: string, flagKey: string, envKey?: string): Promise<Flag> {
+		const envParam = envKey ? '?env=' + envKey : '';
+		const options = this.createOptions(`flags/${projectKey}/${flagKey + envParam}`);
+		const data = await rp(options);
+		return JSON.parse(data);
+	}
+
+	private createOptions(path: string) {
+		return {
+			url: url.resolve(configuration.baseUri, `api/v2/${path}`),
+			headers: {
+				Authorization: configuration.accessToken,
+			},
+		};
+	}
+}
+
+export const api = new LaunchDarklyAPI();

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,59 +1,17 @@
-import * as vscode from 'vscode';
+import { WorkspaceConfiguration, workspace } from 'vscode';
 
 export const DEFAULT_BASE_URI = 'https://app.launchdarkly.com';
 export const DEFAULT_STREAM_URI = 'https://stream.launchdarkly.com';
 
-export interface IConfiguration {
-	/**
-	 * Your LaunchDarkly API access token with reader-level permissions. Required.
-	 */
-	accessToken: string;
-
-	/**
-	 * Your LaunchDarkly SDK key. Required.
-	 */
-	sdkKey: string;
-
-	/**
-	 * Your LaunchDarkly project key, should match the provided SDK key. Required.
-	 */
-	project: string;
-
-	/**
-	 * Your LaunchDarkly environment key, should match the provided SDK key.
-	 */
-	env: string;
-
-	/**
-	 * Enables flag info to be displayed on hover of a valid flag key.
-	 */
-	enableHover: boolean;
-
-	/**
-	 * Enable flag key autocompletion.
-	 */
-	enableAutocomplete: boolean;
-
-	/**
-	 * The LaunchDarkly base uri to be used. Optional.
-	 */
-	baseUri: string;
-
-	/**
-	 * The LaunchDarkly stream uri to be used. Optional.
-	 */
-	streamUri: string;
-}
-
-class Configuration implements IConfiguration {
+class Configuration {
 	constructor() {
 		this.reload();
 	}
 
 	reload() {
-		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('launchdarkly');
+		let config: WorkspaceConfiguration = workspace.getConfiguration('launchdarkly');
 		for (const option in this) {
-			this[option] = config[option];
+			this[option] = config.get(option);
 		}
 	}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 
 import { workspace, ExtensionContext, ConfigurationChangeEvent } from 'vscode';
 
-import { flagStore  } from './flags';
+import { flagStore } from './flags';
 import { configuration as config } from './configuration';
 
 export function activate(ctx: ExtensionContext) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,25 +1,21 @@
 'use strict';
 
-import * as vscode from 'vscode';
+import { workspace, ExtensionContext, ConfigurationChangeEvent } from 'vscode';
 
-import { LDFlagManager } from './flags';
-import { configuration as settings } from './configuration';
+import { flagStore  } from './flags';
+import { configuration as config } from './configuration';
 
-// Handles changes in vscode configuration and registration of commands/providers
-let flagManager: LDFlagManager;
-
-export function activate(ctx: vscode.ExtensionContext) {
-	vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
+export function activate(ctx: ExtensionContext) {
+	workspace.onDidChangeConfiguration((e: ConfigurationChangeEvent) => {
 		if (e.affectsConfiguration('launchdarkly')) {
-			settings.reload();
-			flagManager.reload(settings);
+			config.reload();
+			flagStore.reload(e);
 		}
 	});
 
-	flagManager = new LDFlagManager(ctx, settings);
-	flagManager.registerProviders(ctx, settings);
+	flagStore.registerProviders(ctx);
 }
 
 export function deactivate() {
-	flagManager.updateProcessor.stop();
+	flagStore.stop();
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,24 @@
+export class Resource {
+	name: string;
+	key: string;
+	tags: Array<string>;
+}
+
+export class Flag extends Resource {
+	environments: Map<String, Environment>;
+}
+
+export class Environment extends Resource {
+	_site: { href: string };
+}
+
+export class FlagConfiguration {
+	key: string;
+	variations: Array<any>;
+	offVariation: any;
+	fallthrough: any;
+	prerequisites: any;
+	targets: any;
+	rules: Array<any>;
+	on: boolean;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2539,6 +2539,11 @@ psl@^1.1.24:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.6.0.tgz#60557582ee23b6c43719d9890fb4170ecd91e110"
   integrity sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA==
 
+psl@^1.1.28:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.7.0.tgz#f1c4c47a8ef97167dea5d6bbf4816d736e884a3c"
+  integrity sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==
+
 public-encrypt@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
@@ -2586,7 +2591,7 @@ punycode@^1.2.4, punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-punycode@^2.1.0:
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
@@ -2719,6 +2724,22 @@ request-etag@^2.0.3:
     lodash.clonedeep "^4.0.1"
     lru-cache "^4.0.0"
     request "^2.67.0"
+
+request-promise-core@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.3.tgz#e9a3c081b51380dfea677336061fea879a829ee9"
+  integrity sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==
+  dependencies:
+    lodash "^4.17.15"
+
+request-promise-native@1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.8.tgz#a455b960b826e44e2bf8999af64dff2bfe58cb36"
+  integrity sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==
+  dependencies:
+    request-promise-core "1.1.3"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
 
 request@2.88.0, request@^2.67.0:
   version "2.88.0"
@@ -3015,6 +3036,11 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
+stealthy-require@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+  integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
@@ -3190,6 +3216,14 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+tough-cookie@^2.3.3:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
 
 tough-cookie@~2.4.3:
   version "2.4.3"


### PR DESCRIPTION
This is the start of a series of PRs that will break ld-vscode into more manageable pieces.

- Refactor existing classes into singletons
- Break out API code and data types into separate classes / files
- Rename `LDFlagManager` to `FlagStore` and move most unrelated functionality out into separate functions.
