### PR TITLE
Add flag name to flag hover information

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -176,6 +176,7 @@ const openFlagInBrowser = async (config: Configuration, flagKey: string, api: La
 
 export function generateHoverString(flag: FlagConfiguration) {
 	return `**LaunchDarkly feature flag**\n
+        Name: ${flag.name}
 	Key: ${flag.key}
 	Enabled: ${flag.on}
 	Default variation: ${JSON.stringify(flag.variations[flag.fallthrough.variation])}


### PR DESCRIPTION
**Motivation**
We use random flag keys for more secure client side flags.  Hover info with only the key in this case does not help us remember what the flag controls.