### PR TITLE
add Open in Browser to hover card

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -120,7 +120,10 @@ class LaunchDarklyHoverProvider implements HoverProvider {
 						(await this.flagStore.getFeatureFlag(candidate)) ||
 						(await this.flagStore.getFeatureFlag(kebabCase(candidate)));
 					if (data) {
-						const hover = generateHoverString(data.flag, data.config, this.config);
+						let env = data.flag.environments[this.config.env];
+						let sitePath = env._site.href;
+						let browserURL = url.resolve(this.config.baseUri, sitePath)
+						const hover = generateHoverString(data.flag, data.config, browserURL);
 						resolve(new Hover(hover));
 						return;
 					}
@@ -180,7 +183,7 @@ const openFlagInBrowser = async (config: Configuration, flagKey: string, flagSto
 	opn(url.resolve(config.baseUri, sitePath));
 };
 
-export function generateHoverString(flag: Flag, c: FlagConfiguration, config: Configuration) {
+export function generateHoverString(flag: Flag, c: FlagConfiguration, url?: string) {
 	const fields = [
 		['Name', flag.name],
 		['Key', c.key],
@@ -205,10 +208,9 @@ export function generateHoverString(flag: Flag, c: FlagConfiguration, config: Co
 			hoverString = hoverString.appendCodeblock(`${field[1]}`);
 		}
 	});
-	if (config.env != null) {
-		let browserURL = url.resolve(config.baseUri, flag.environments[config.env]._site.href)
+	if (url) {
 		hoverString.appendText('\n')
-		hoverString = hoverString.appendMarkdown(`[Open In Browser](${browserURL})`)
+		hoverString = hoverString.appendMarkdown(`[Open In Browser](${url})`)
 		hoverString.isTrusted = true
 	}
 	return hoverString;

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -120,7 +120,7 @@ class LaunchDarklyHoverProvider implements HoverProvider {
 						(await this.flagStore.getFeatureFlag(candidate)) ||
 						(await this.flagStore.getFeatureFlag(kebabCase(candidate)));
 					if (data) {
-						const hover = generateHoverString(data.flag, data.config);
+						const hover = generateHoverString(data.flag, data.config, this.config);
 						resolve(new Hover(hover));
 						return;
 					}
@@ -180,7 +180,7 @@ const openFlagInBrowser = async (config: Configuration, flagKey: string, flagSto
 	opn(url.resolve(config.baseUri, sitePath));
 };
 
-export function generateHoverString(flag: Flag, c: FlagConfiguration) {
+export function generateHoverString(flag: Flag, c: FlagConfiguration, config: Configuration) {
 	const fields = [
 		['Name', flag.name],
 		['Key', c.key],
@@ -205,6 +205,12 @@ export function generateHoverString(flag: Flag, c: FlagConfiguration) {
 			hoverString = hoverString.appendCodeblock(`${field[1]}`);
 		}
 	});
+	if (config.env != null) {
+		let browserURL = url.resolve(config.baseUri, flag.environments[config.env]._site.href)
+		hoverString.appendText('\n')
+		hoverString = hoverString.appendMarkdown(`[Open In Browser](${browserURL})`)
+		hoverString.isTrusted = true
+	}
 	return hoverString;
 }
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -210,7 +210,7 @@ export function generateHoverString(flag: Flag, c: FlagConfiguration, url?: stri
 	});
 	if (url) {
 		hoverString.appendText('\n')
-		hoverString = hoverString.appendMarkdown(`[Open In Browser](${url})`)
+		hoverString = hoverString.appendMarkdown(`[Open in browser](${url})`)
 		hoverString.isTrusted = true
 	}
 	return hoverString;

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -4,6 +4,8 @@ import * as vscode from 'vscode';
 
 import * as providers from '../src/providers';
 import { Flag, FlagConfiguration } from '../src/models';
+import * as configs from '../src/configuration';
+import { ExtensionContext } from 'vscode';
 
 const flag = new Flag ({
 	name: "Test",
@@ -32,8 +34,8 @@ let testPath = path.join(__dirname, '..', '..', 'test');
 suite('provider utils tests', () => {
 	test('generateHoverString', () => {
 		assert.equal(
-			"**LaunchDarkly feature flag**\n\nName: \n```\nTest\n```\n\n\nKey: \n```\ntest\n```\n\n\nEnabled: \n```\ntrue\n```\n\n\nDefault variation: \n```\n\"SomeVariation\"\n```\n\n\nOff variation: \n```\n{\n  \"thisIsJson\": \"AnotherVariation\"\n}\n```\n\n\n1 prerequisite\n\n3 user targets\n\n0 rules",
-			providers.generateHoverString(flag, flagConfig).value,
+			"**LaunchDarkly feature flag**\n\nName: \n```\nTest\n```\n\n\nKey: \n```\ntest\n```\n\n\nEnabled: \n```\ntrue\n```\n\n\nDefault variation: \n```\n\"SomeVariation\"\n```\n\n\nOff variation: \n```\n{\n  \"thisIsJson\": \"AnotherVariation\"\n}\n```\n\n\n1 prerequisite\n\n3 user targets\n\n0 rules\nOpen in Browser",
+			providers.generateHoverString(flag, flagConfig, "http://app.launchdarkly.com/example").value,
 		);
 	});
 

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -4,8 +4,6 @@ import * as vscode from 'vscode';
 
 import * as providers from '../src/providers';
 import { Flag, FlagConfiguration } from '../src/models';
-import * as configs from '../src/configuration';
-import { ExtensionContext } from 'vscode';
 
 const flag = new Flag ({
 	name: "Test",

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -32,7 +32,7 @@ let testPath = path.join(__dirname, '..', '..', 'test');
 suite('provider utils tests', () => {
 	test('generateHoverString', () => {
 		assert.equal(
-			"**LaunchDarkly feature flag**\n\nName: \n```\nTest\n```\n\n\nKey: \n```\ntest\n```\n\n\nEnabled: \n```\ntrue\n```\n\n\nDefault variation: \n```\n\"SomeVariation\"\n```\n\n\nOff variation: \n```\n{\n  \"thisIsJson\": \"AnotherVariation\"\n}\n```\n\n\n1 prerequisite\n\n3 user targets\n\n0 rules\nOpen in Browser",
+			"**LaunchDarkly feature flag**\n\nName: \n```\nTest\n```\n\n\nKey: \n```\ntest\n```\n\n\nEnabled: \n```\ntrue\n```\n\n\nDefault variation: \n```\n\"SomeVariation\"\n```\n\n\nOff variation: \n```\n{\n  \"thisIsJson\": \"AnotherVariation\"\n}\n```\n\n\n1 prerequisite\n\n3 user targets\n\n0 rules\nOpen in browser",
 			providers.generateHoverString(flag, flagConfig, "http://app.launchdarkly.com/example").value,
 		);
 	});


### PR DESCRIPTION
Currently the test generateHoverString will be broken with this PR. I've commented it out locally and tested the functionality of the change. I am not sure how to modify the test though to mock out `ExtensionContext`