### PR TITLE
Fix configuration issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "launchdarkly",
 	"displayName": "LaunchDarkly",
 	"description": "Manage LaunchDarkly feature flags directly from within your code",
-	"version": "3.0.2",
+	"version": "3.0.3",
 	"publisher": "launchdarklyofficial",
 	"engines": {
 		"vscode": "^1.52.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"icon": "images/launchdarkly.png",
 	"license": "SEE LICENSE IN LICENSE.txt",
 	"activationEvents": [
-		"*"
+		"onStartupFinished"
 	],
 	"main": "./dist/extension",
 	"contributes": {
@@ -75,6 +75,11 @@
 				"launchdarkly.enableCodeLens": {
 					"type": "boolean",
 					"default": false
+				},
+				"launchdarkly.accessToken": {
+					"type": "string",
+					"default": "",
+					"description": "LaunchDarkly API access token. DEPRECATED: Run the 'LaunchDarkly: Configure' command instead."
 				}
 			}
 		},

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -49,7 +49,6 @@ export class Configuration {
 		if (key === 'accessToken') {
 			const ctxState = global ? this.ctx.globalState : this.ctx.workspaceState;
 			await ctxState.update(key, value);
-			await config.update(key, '', global);
 			return;
 		}
 		await config.update(key, value, global);

--- a/src/configurationMenu.ts
+++ b/src/configurationMenu.ts
@@ -48,7 +48,7 @@ export class ConfigurationMenu {
 		const existingTokenName = 'Use the existing access token';
 		const options = [
 			{ name: existingTokenName, key: 'xxxx' + this.currentAccessToken.substr(this.currentAccessToken.length - 6) },
-			{ name: 'Enter a new access token' },
+			{ name: 'Enter a new access token' }
 		].map(this.createQuickPickItem);
 
 		const pick = await input.showQuickPick({
@@ -152,8 +152,8 @@ export class ConfigurationMenu {
 	async pickStorageType(input: MultiStepInput) {
 		const allWorkspacesName = 'All workspaces';
 		const storageOptions = [
-			{ name: 'This workspace', key: workspace.name },
 			{ name: allWorkspacesName, key: 'Workspace-specific configurations will take precedence' },
+			{ name: 'This workspace', key: workspace.name },
 		].map(this.createQuickPickItem);
 
 		const pick = await input.showQuickPick({
@@ -181,7 +181,8 @@ export class ConfigurationMenu {
 
 	async configure() {
 		await this.collectInputs();
-		['project', 'env'].forEach(async option => {
+		['accessToken', 'project', 'env'].forEach(async option => {
+			console.log(option)
 			await this.config.update(option, this[option], this.useGlobalState);
 		});
 	}

--- a/src/configurationMenu.ts
+++ b/src/configurationMenu.ts
@@ -47,8 +47,8 @@ export class ConfigurationMenu {
 	async pickCurrentOrNewAccessToken(input: MultiStepInput) {
 		const existingTokenName = 'Use the existing access token';
 		const options = [
-			{ name: existingTokenName, key: 'xxxx' + this.currentAccessToken.substr(this.currentAccessToken.length - 6) },
 			{ name: 'Enter a new access token' },
+			{ name: existingTokenName, key: 'xxxx' + this.currentAccessToken.substr(this.currentAccessToken.length - 6) },
 		].map(this.createQuickPickItem);
 
 		const pick = await input.showQuickPick({

--- a/src/configurationMenu.ts
+++ b/src/configurationMenu.ts
@@ -182,7 +182,6 @@ export class ConfigurationMenu {
 	async configure() {
 		await this.collectInputs();
 		['accessToken', 'project', 'env'].forEach(async option => {
-			console.log(option);
 			await this.config.update(option, this[option], this.useGlobalState);
 		});
 	}

--- a/src/configurationMenu.ts
+++ b/src/configurationMenu.ts
@@ -48,7 +48,7 @@ export class ConfigurationMenu {
 		const existingTokenName = 'Use the existing access token';
 		const options = [
 			{ name: existingTokenName, key: 'xxxx' + this.currentAccessToken.substr(this.currentAccessToken.length - 6) },
-			{ name: 'Enter a new access token' }
+			{ name: 'Enter a new access token' },
 		].map(this.createQuickPickItem);
 
 		const pick = await input.showQuickPick({
@@ -182,7 +182,7 @@ export class ConfigurationMenu {
 	async configure() {
 		await this.collectInputs();
 		['accessToken', 'project', 'env'].forEach(async option => {
-			console.log(option)
+			console.log(option);
 			await this.config.update(option, this[option], this.useGlobalState);
 		});
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,15 +15,21 @@ let flagStore: FlagStore;
 export async function activate(ctx: ExtensionContext): Promise<void> {
 	config = new Configuration(ctx);
 	const validationError = config.validate();
+	const configuredOnce = ctx.globalState.get("LDConfigured")
 	switch (validationError) {
 		case 'unconfigured':
-			window
-				.showInformationMessage('To enable the LaunchDarkly extension, select your desired environment.', 'Configure')
-				.then(item => {
-					item === 'Configure'
-						? commands.executeCommand('extension.configureLaunchDarkly')
-						: ctx.workspaceState.update('isDisabledForWorkspace', true);
-				});
+			if (window.activeTextEditor !== undefined && configuredOnce !== true) {
+				window
+					.showInformationMessage(
+						`To enable the LaunchDarkly extension, select your desired environment. If this message is dismissed, LaunchDarkly will be disabled for the workspace`,
+						'Configure',
+					)
+					.then(item => {
+						item === 'Configure'
+							? commands.executeCommand('extension.configureLaunchDarkly')
+							: ctx.workspaceState.update('isDisabledForWorkspace', true);
+					});
+			}
 			break;
 		case 'legacy':
 			window

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ let flagStore: FlagStore;
 export async function activate(ctx: ExtensionContext): Promise<void> {
 	config = new Configuration(ctx);
 	const validationError = config.validate();
-	const configuredOnce = ctx.globalState.get("LDConfigured")
+	const configuredOnce = ctx.globalState.get('LDConfigured');
 	switch (validationError) {
 		case 'unconfigured':
 			if (window.activeTextEditor !== undefined && configuredOnce !== true) {

--- a/src/flagStore.ts
+++ b/src/flagStore.ts
@@ -198,6 +198,9 @@ export class FlagStore {
 	}
 
 	getFeatureFlag(key: string): Promise<FlagWithConfiguration | null> {
+		if (this.flagMetadata === undefined) {
+			return null
+		}
 		let flag = this.flagMetadata[key];
 		return new Promise((resolve, reject) => {
 			this.store.get(DATA_KIND, key, async (res: FlagConfiguration) => {

--- a/src/flagStore.ts
+++ b/src/flagStore.ts
@@ -199,7 +199,7 @@ export class FlagStore {
 
 	getFeatureFlag(key: string): Promise<FlagWithConfiguration | null> {
 		if (this.flagMetadata === undefined) {
-			return null
+			return null;
 		}
 		let flag = this.flagMetadata[key];
 		return new Promise((resolve, reject) => {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -135,7 +135,7 @@ export async function register(
 						}
 					}
 				}
-				console.error(`Providers ${err}`);
+				console.error(`${err}`);
 				window.showErrorMessage(`[LaunchDarkly] ${errMsg}`);
 			}
 		}),

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -73,7 +73,7 @@ export async function register(
 					await flagStore.reload();
 					commands.executeCommand('launchdarkly.refreshEntry');
 				}
-
+				await ctx.globalState.update('LDConfigured', true);
 				window.showInformationMessage('LaunchDarkly configured successfully');
 			} catch (err) {
 				console.error(err);
@@ -135,7 +135,7 @@ export async function register(
 						}
 					}
 				}
-				console.error(err);
+				console.error(`Providers ${err}`);
 				window.showErrorMessage(`[LaunchDarkly] ${errMsg}`);
 			}
 		}),

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -42,7 +42,7 @@ export class LaunchDarklyHoverProvider implements HoverProvider {
 				let aliases;
 				let foundAlias = [];
 				if (typeof this.aliases !== undefined) {
-					aliases = this.aliases.getMap();
+					aliases = this.aliases?.getMap();
 					if (aliases !== undefined && aliases.length > 0) {
 						const aliasKeys = Object.keys(aliases) ? Object.keys(aliases) : [];
 						const aliasArr = [...aliasKeys].filter(element => element !== '');


### PR DESCRIPTION
With the removal of `accessToken` with the cleanup of v3 it had the unattended effect of not allowing configuration to be saved at all. Along with this I've made 3 additional small changes:

* Add a globalState for if the extension has been configured at least once through the window info message. If so it will not show again for any workspaces. This will need to be extended to configuration flow itself and not just based on it going through the info message.
* Initialization changed from `*` to `onStartupFinished` which is the preferred method. https://code.visualstudio.com/api/references/activation-events#onStartupFinished