### PR TITLE
Fix Flag Search when no Aliases are present

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "launchdarkly",
 	"displayName": "LaunchDarkly",
 	"description": "Manage LaunchDarkly feature flags directly from within your code",
-	"version": "3.0.3",
+	"version": "3.0.4",
 	"publisher": "launchdarklyofficial",
 	"engines": {
 		"vscode": "^1.52.0"

--- a/src/providers/flagsView.ts
+++ b/src/providers/flagsView.ts
@@ -123,7 +123,7 @@ export class LaunchDarklyTreeViewProvider implements vscode.TreeDataProvider<Fla
 				if (this.aliases) {
 					aliases = this.aliases.getKeys();
 				}
-				if (aliases[node.flagKey]) {
+				if (aliases && aliases[node.flagKey]) {
 					const tempSearch = [...aliases[node.flagKey]];
 					tempSearch.push(node.flagKey);
 					findAliases = tempSearch.join('|');


### PR DESCRIPTION
The command for searching for all flag references was not working for a single flag key with no aliases. This change fixes that.