### PR TITLE
Refactor Settings

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @launchdarkly/developer-flow

--- a/src/commands/configureLaunchDarkly.ts
+++ b/src/commands/configureLaunchDarkly.ts
@@ -3,7 +3,7 @@ import { LaunchDarklyAPI } from '../api';
 import { Configuration } from '../configuration';
 import { ConfigurationMenu } from '../configurationMenu';
 import { FlagStore } from '../flagStore';
-import { createViews } from '../utils';
+import { setupComponents } from '../utils';
 
 export default async function configureLaunchDarkly(
 	ctx: ExtensionContext,
@@ -21,7 +21,7 @@ export default async function configureLaunchDarkly(
 				await flagStore.reload();
 			}
 
-			await createViews(api, config, ctx, flagStore);
+			await setupComponents(api, config, ctx, flagStore);
 			await ctx.globalState.update('LDConfigured', true);
 			window.showInformationMessage('LaunchDarkly configured successfully');
 		} catch (err) {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -48,7 +48,21 @@ export class Configuration {
 
 		// If accessToken is configured in state, use it. Otherwise, fall back to the legacy access token.
 		const accessToken = this.getState('accessToken') || this.accessToken;
-		const env = this.getState('env') || this.env;
+		if (!this.getState('env')) {
+			this.ctx.workspaceState.update('env', this.env);
+		}
+		const env = this.getState('env');
+
+		if (!this.getState('project')) {
+			this.ctx.workspaceState.update('project', this.project);
+		}
+		const project = this.getState('project');
+
+		if (!this.getState('baseUri')) {
+			this.ctx.workspaceState.update('baseUri', this.baseUri);
+		}
+		const baseUri = this.getState('baseUri');
+
 		const debugChannel = this.ctx.workspaceState.get('debugChannel', '');
 		const debugCipher = this.ctx.workspaceState.get('debugCipher', '');
 
@@ -58,6 +72,8 @@ export class Configuration {
 		}
 		this.accessToken = accessToken;
 		this.env = env;
+		this.project = project;
+		this.baseUri = baseUri;
 		this.debugChannel = debugChannel;
 		this.debugCipher = debugCipher;
 	}

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -28,7 +28,7 @@ import { ClientSideEnable, refreshDiagnostics, subscribeToDocumentChanges } from
 import PubNub from 'pubnub';
 import globalClearCmd from './commands/clearGlobalContext';
 import configureLaunchDarkly from './commands/configureLaunchDarkly';
-import { createViews } from './utils';
+import { setupComponents } from './utils';
 import createFlagCmd from './commands/createFlag';
 
 const STRING_DELIMETERS = ['"', "'", '`'];
@@ -111,24 +111,14 @@ export async function register(
 			await config.reload();
 			const newApi = new LaunchDarklyAPI(config);
 			flagStore = new FlagStore(config, newApi);
-			await createViews(api, config, ctx, flagStore);
+			await setupComponents(newApi, config, ctx, flagStore);
 		}
 	});
 	if (!config.isConfigured) {
 		return;
 	}
 	if (typeof flagStore !== 'undefined') {
-		if (config.enableAliases) {
-			aliases = new FlagAliases(config, ctx);
-			if (aliases.codeRefsVersionCheck()) {
-				aliases.setupStatusBar();
-				aliases.start();
-			} else {
-				window.showErrorMessage('ld-find-code-refs version > 2 supported.');
-			}
-		}
-
-		await createViews(api, config, ctx, flagStore, aliases);
+		await setupComponents(api, config, ctx, flagStore, aliases);
 
 		const Lddebugger = window.createOutputChannel('LaunchDarkly All');
 		const LddIdentify = window.createOutputChannel('LaunchDarkly Identify Debug');

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -45,13 +45,11 @@ export class LaunchDarklyHoverProvider implements HoverProvider {
 				}
 				let aliases;
 				let foundAlias = [];
-				if (typeof this.aliases !== undefined) {
+				if (typeof this.aliases !== 'undefined') {
 					aliases = this.aliases?.getMap();
-					if (typeof aliases !== undefined) {
-						const aliasKeys = Object.keys(aliases) ? Object.keys(aliases) : [];
-						const aliasArr = [...aliasKeys].filter((element) => element !== '');
-						foundAlias = aliasArr.filter((element) => candidate.includes(element));
-					}
+					const aliasKeys = Object.keys(aliases) ? Object.keys(aliases) : [];
+					const aliasArr = [...aliasKeys].filter((element) => element !== '');
+					foundAlias = aliasArr.filter((element) => candidate.includes(element));
 				} else {
 					aliases = [];
 				}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ export default async function checkExistingCommand(commandName: string): Promise
 	return false;
 }
 
-export async function createViews(
+export async function setupComponents(
 	api: LaunchDarklyAPI,
 	config: Configuration,
 	ctx: ExtensionContext,
@@ -38,6 +38,16 @@ export async function createViews(
 	const quickLinksView = new QuickLinksListProvider(config, flagStore);
 	window.registerTreeDataProvider('launchdarklyQuickLinks', quickLinksView);
 	await quickLinksView.reload();
+
+	if (config.enableAliases) {
+		aliases = new FlagAliases(config, ctx);
+		if (aliases.codeRefsVersionCheck()) {
+			aliases.setupStatusBar();
+			aliases.start();
+		} else {
+			window.showErrorMessage('ld-find-code-refs version > 2 supported.');
+		}
+	}
 
 	const codeLens = new FlagCodeLensProvider(api, config, flagStore, aliases);
 	const listView = new LaunchDarklyFlagListProvider(config, codeLens);


### PR DESCRIPTION
* Rename `createView` to be clearer
* move aliases inside of setupComponents
* fix bug where new api client was not being passed in with a configuration update
 * add CODEOWNERS