### PR TITLE
[REL-7521] upgrade gh actions versions for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Extract branch name
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # 4.4.0
         with:
-          node-version: '18.19.0'
+          node-version: '22.13.0'
       - run: yarn
       - run: yarn build:setup
       - run: yarn prepare-beta


### PR DESCRIPTION
release.yaml has outdated versions for some GH actions needed for releasing so I've upgraded them
<!-- ld-jira-link -->
---
Related Jira issue: [REL-7521: Fix bug in LD VS Code Integration setup process](https://launchdarkly.atlassian.net/browse/REL-7521)
<!-- end-ld-jira-link -->