### PR TITLE
Bumping versions to catch up with published version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "launchdarkly" extension will be documented in this file.
 
+
+## [6.1.0] - 2025-12-05
+- Bumping major and minor version to address rogue published version that is not captured in our package.json
+
+
 ## [5.1.0] - 2025-09-01
  
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "launchdarkly",
 	"displayName": "LaunchDarkly",
 	"description": "Manage LaunchDarkly feature flags directly from within your code",
-	"version": "5.1.0",
+	"version": "6.1.0",
 	"publisher": "launchdarklyofficial",
 	"engines": {
 		"vscode": "^1.82.0"


### PR DESCRIPTION
VSCodes marketplace is listing our most recent version as 6.0.12. My best guess is that this was inadvertently published from a local branch.

The version our GH actions publish is pulled from the package.json definition.

This is causing some of the functionality related to the quick targeting command to fail which is only reproduceable in that 6. published version, local builds and debugging do not reproduce the issue.

Adjusting the changelog and package.json appropriately to publish a new version.
This should also cause the OpenVSIX listing (which is used by Cursor) to update to this version as well.

<img width="1617" height="936" alt="Screenshot 2025-12-05 at 1 10 27 PM" src="https://github.com/user-attachments/assets/ed5f794c-8a8c-440a-b596-17b7d5ff08c0" />


