### PR TITLE
Update CODEOWNERS: rename team-fm-next to team-fm-foundations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @launchdarkly/team-fm-next
+* @launchdarkly/team-fm-foundations


### PR DESCRIPTION
## Summary
Renames the CODEOWNERS team reference from `@launchdarkly/team-fm-next` to `@launchdarkly/team-fm-foundations` to reflect the team rename.

This is part of a batch update across multiple repos in the LaunchDarkly org.

## Review & Testing Checklist for Human
- [ ] Verify that `@launchdarkly/team-fm-foundations` is a valid GitHub team in the org and has the expected members

### Notes
Repos updated in this batch: `ld-find-code-refs`, `find-code-references-in-pull-request`, `find-code-references`, `ld-vscode`, `ld-openapi`. The `agent-skills` repo was already using the new team name.

Link to Devin session: https://app.devin.ai/sessions/8abe80d07e414755864c1b9c67215686
Requested by: @kparkinson-ld